### PR TITLE
fix: first readme example does not use a string slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use CertMagic:
 
 ```go
 // encrypted HTTPS with HTTP->HTTPS redirects - yay! 🔒😍
-certmagic.HTTPS("example.com", mux)
+certmagic.HTTPS([]string{"example.com"}, mux)
 ```
 
 That line of code will serve your HTTP router `mux` over HTTPS, complete with HTTP->HTTPS redirects. It obtains and renews the TLS certificates. It staples OCSP responses for greater privacy and security. As long as your domain name points to your server, CertMagic will keep its connections secure.


### PR DESCRIPTION
Minor documentation error. Seems like the rest of the doc is correct, but as I copy-pasta'd this, I was very sad that it didn't work first go.

> __Edit:__ I also read [don't push your pull requests](https://www.igvita.com/2011/12/19/dont-push-your-pull-requests/) far too late. I can retry if you'd prefer 😨 