### PR TITLE
Replace TryLock and Wait with Lock, and check for idempotency

### DIFF
--- a/certificates.go
+++ b/certificates.go
@@ -64,12 +64,11 @@ func (c Certificate) NeedsRenewal() bool {
 	if c.NotAfter.IsZero() {
 		return false
 	}
-	timeLeft := c.NotAfter.UTC().Sub(time.Now().UTC())
 	renewDurationBefore := DefaultRenewDurationBefore
 	if len(c.configs) > 0 && c.configs[0].RenewDurationBefore > 0 {
 		renewDurationBefore = c.configs[0].RenewDurationBefore
 	}
-	return timeLeft < renewDurationBefore
+	return time.Until(c.NotAfter) < renewDurationBefore
 }
 
 // CacheManagedCertificate loads the certificate for domain into the

--- a/client.go
+++ b/client.go
@@ -208,6 +208,8 @@ func (cfg *Config) newACMEClient(interactive bool) (*acmeClient, error) {
 	return c, nil
 }
 
+// lockKey returns a key for a lock that is specific to the operation
+// named op being performed related to domainName and this config's CA.
 func (cfg *Config) lockKey(op, domainName string) string {
 	return fmt.Sprintf("%s:%s:%s", op, domainName, cfg.CA)
 }
@@ -215,29 +217,32 @@ func (cfg *Config) lockKey(op, domainName string) string {
 // Obtain obtains a single certificate for name. It stores the certificate
 // on the disk if successful. This function is safe for concurrent use.
 //
-// Right now our storage mechanism only supports one name per certificate,
-// so this function (along with Renew and Revoke) only accepts one domain
-// as input. It can be easily modified to support SAN certificates if our
-// storage mechanism is upgraded later.
+// Our storage mechanism only supports one name per certificate, so this
+// function (along with Renew and Revoke) only accepts one domain as input.
+// It could be easily modified to support SAN certificates if our storage
+// mechanism is upgraded later, but that will increase logical complexity
+// in other areas.
 //
 // Callers who have access to a Config value should use the ObtainCert
 // method on that instead of this lower-level method.
 func (c *acmeClient) Obtain(name string) error {
+	// ensure idempotency of the obtain operation for this name
 	lockKey := c.config.lockKey("cert_acme", name)
-	waiter, err := c.config.certCache.storage.TryLock(lockKey)
+	err := c.config.certCache.storage.Lock(lockKey)
 	if err != nil {
 		return err
 	}
-	if waiter != nil {
-		log.Printf("[INFO] Certificate for %s is already being obtained elsewhere and stored; waiting", name)
-		waiter.Wait()
-		return nil // we assume the process with the lock succeeded, rather than hammering this execution path again
-	}
 	defer func() {
 		if err := c.config.certCache.storage.Unlock(lockKey); err != nil {
-			log.Printf("[ERROR] Unable to unlock obtain call for %s: %v", name, err)
+			log.Printf("[ERROR] Obtain: Unable to unlock '%s' for '%s': %v", lockKey, name, err)
 		}
 	}()
+
+	// check if obtain is still needed -- might have
+	// been obtained during lock
+	if c.config.storageHasCertResources(name) {
+		return nil
+	}
 
 	for attempts := 0; attempts < 2; attempts++ {
 		request := certificate.ObtainRequest{
@@ -280,19 +285,15 @@ func (c *acmeClient) Obtain(name string) error {
 // Callers who have access to a Config value should use the RenewCert
 // method on that instead of this lower-level method.
 func (c *acmeClient) Renew(name string) error {
+	// ensure idempotency of the renew operation for this name
 	lockKey := c.config.lockKey("cert_acme", name)
-	waiter, err := c.config.certCache.storage.TryLock(lockKey)
+	err := c.config.certCache.storage.Lock(lockKey)
 	if err != nil {
 		return err
 	}
-	if waiter != nil {
-		log.Printf("[INFO] Certificate for %s is already being renewed elsewhere and stored; waiting", name)
-		waiter.Wait()
-		return nil // assume that the worker that renewed the cert succeeded to avoid hammering this path over and over
-	}
 	defer func() {
 		if err := c.config.certCache.storage.Unlock(lockKey); err != nil {
-			log.Printf("[ERROR] Unable to unlock renew call for %s: %v", name, err)
+			log.Printf("[ERROR] Renew: Unable to unlock '%s' for '%s': %v", lockKey, name, err)
 		}
 	}()
 
@@ -300,6 +301,11 @@ func (c *acmeClient) Renew(name string) error {
 	certRes, err := c.config.loadCertResource(name)
 	if err != nil {
 		return err
+	}
+
+	// Check if renew is still needed - might have been renewed while waiting for lock
+	if !c.config.managedCertNeedsRenewal(certRes) {
+		return nil
 	}
 
 	// Perform renewal and retry if necessary, but not too many times.

--- a/storage.go
+++ b/storage.go
@@ -64,22 +64,24 @@ type Storage interface {
 // Locker facilitates synchronization of certificate tasks across
 // machines and networks.
 type Locker interface {
-	// TryLock will attempt to acquire the lock for key. If a
-	// lock could be obtained, nil values are returned as no
-	// waiting is required. If not (meaning another process is
-	// already working on key), a Waiter value will be returned,
-	// upon which you should Wait() until it is finished.
+	// Lock acquires the lock for key, blocking until the lock
+	// can be obtained or an error is returned. Note that, even
+	// after acquiring a lock, an idempotent operation may have
+	// already been performed by another process that acquired
+	// the lock before - so always check to make sure idempotent
+	// operations still need to be performed after acquiring the
+	// lock.
 	//
 	// The actual implementation of obtaining of a lock must be
-	// an atomic operation so that multiple TryLock calls at the
+	// an atomic operation so that multiple Lock calls at the
 	// same time always results in only one caller receiving the
-	// lock. TryLock always returns without waiting.
+	// lock at any given time.
 	//
 	// To prevent deadlocks, all implementations (where this concern
 	// is relevant) should put a reasonable expiration on the lock in
 	// case Unlock is unable to be called due to some sort of network
 	// or system failure or crash.
-	TryLock(key string) (Waiter, error)
+	Lock(key string) error
 
 	// Unlock releases the lock for key. This method must ONLY be
 	// called after a successful call to TryLock where no Waiter was
@@ -98,11 +100,6 @@ type Locker interface {
 	// should be printed or logged, since there could be multiple,
 	// with no good way to handle them anyway.
 	UnlockAllObtained()
-}
-
-// Waiter is a type that can block until a lock is released.
-type Waiter interface {
-	Wait()
 }
 
 // KeyInfo holds information about a key in storage.


### PR DESCRIPTION
This replaces TryLock and Wait with a single Lock function, and we check after obtaining a lock to make sure Obtain and Renew remain idempotent.

See issue #5.

/cc @DisposaBoy - please help test and review!