### PR TITLE
Added s3 storage module and tests.  Updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,37 @@ The easiest way to change the storage being used is to set `certmagic.DefaultSto
 
 If you write a Storage implementation, let us know and we'll add it to the project so people can find it!
 
+#### S3Storage
+
+S3Storage is a storage module to make use of amazon's s3 object storage as a storage interface for CertMagic.  S3Storage
+is an implementation of the Storage interface which can be used to back services behind a load balancer without
+needing to expose the servers themselves to the internet.  It is expected that users needing this storage will
+have the requisite knowledge to understand when it is necessary to use this Storage Type in lieu of the default
+Filestorage type.  Because this storage type is typically used behind a load balancer. it is most commonly used in
+conjunction with the __DNS-01__ lego challenge.
+
+The `certmagic.NewS3Storage(bucket, region string)` function requires the name of the s3 bucket to be used as well as
+the region for the s3 bucket.  __NOTE:__ Even though s3 buckets are "global", this is still a region associated with buckets.
+do not pass an empty string
+
+The `NewS3Storage()` function will automatically use credentials from ENV vars, `~/.aws/credentials` files and any assumed roles.
+It should not be necessary to provide any explicit credentials.
+
+Used with the certmagic HTTPS command and a dns provider:
+```
+dnsProvider, err := route53.NewDNSProvider()
+if err != nil {
+    return err
+}
+
+certmagic.DNSProvider = dnsProvider
+certmagic.DefaultStorage = certmagic.NewS3Storage("my-example-s3-bucket", "example-aws-region")
+
+//Then use as normal
+
+certmagic.HTTPS([]string{"example.com"}, handler)
+```
+
 
 ## Cache
 

--- a/s3storage.go
+++ b/s3storage.go
@@ -3,16 +3,17 @@ package certmagic
 import (
 	"bytes"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"io/ioutil"
 	"log"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
 
 const (

--- a/s3storage.go
+++ b/s3storage.go
@@ -1,0 +1,278 @@
+package certmagic
+
+import (
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"path/filepath"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"bytes"
+	"io/ioutil"
+	"fmt"
+	"time"
+	"log"
+	"strings"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+)
+
+const (
+	lockFileExists = "Lock file for already exists"
+)
+
+
+// S3Storage implements the certmagic Storage interface using amazon's
+// s3 storage.  An effort has been made to make the S3Storage implementation
+// as similar as possible to the original filestorage type in order to
+// provide a consistent approach to storage backends for certmagic
+// for issues, please contact @securityclippy
+// S3Storage is safe to use with multiple servers behind an AWS load balancer
+// and is safe for concurrent use
+
+type S3Storage struct {
+	Path string
+	bucket *string
+	svc s3iface.S3API
+}
+
+func NewS3Storage(bucketName, aws_region string) *S3Storage {
+	cfg := aws.NewConfig()
+	cfg.Region = aws.String(aws_region)
+	sess, err := session.NewSession(cfg)
+	if err != nil {
+		panic(err)
+	}
+	svc := s3.New(sess)
+
+	store := &S3Storage{
+		bucket:aws.String(bucketName),
+		svc:svc,
+		Path: "certmagic",
+
+	}
+
+	return store
+}
+
+// Exists returns true if key exists in s3
+func (s *S3Storage) Exists(key string) bool {
+	_, err := s.svc.GetObject(&s3.GetObjectInput{
+		Bucket: s.bucket,
+		Key: aws.String(key),
+	})
+	if err ==  nil {
+		return true
+	}
+	aerr, _ := err.(awserr.Error)
+	return !(aerr.Code() == s3.ErrCodeNoSuchKey)
+}
+
+// Store saves value at key.
+func (s *S3Storage) Store(key string, value []byte) error {
+	filename := s.Filename(key)
+	_, err := s.svc.PutObject(&s3.PutObjectInput{
+		Bucket: s.bucket,
+		Key: aws.String(filename),
+		Body: bytes.NewReader(value),
+	})
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Load retrieves the value at key.
+func (s *S3Storage) Load(key string) ([]byte, error) {
+	result, err := s.svc.GetObject(&s3.GetObjectInput{
+		Bucket: s.bucket,
+		Key: aws.String(s.Filename(key)),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := ioutil.ReadAll(result.Body)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// Delete deletes the value at key.
+func (s *S3Storage) Delete(key string) error {
+	_, err := s.svc.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: s.bucket,
+		Key: aws.String(s.Filename(key)),
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+
+// List returns all keys that match prefix.
+// because s3 has no concept of directories, everything is an explict path,
+// there is really no such thing as recursive search. This is simply
+// here to fullfill the interface requirements of the List function
+func (s *S3Storage) List(prefix string, recursive bool) ([]string, error) {
+	var keys []string
+
+	prefixPath := s.Filename(prefix)
+	result, err := s.svc.ListObjects(&s3.ListObjectsInput{
+		Bucket: s.bucket,
+		Prefix: aws.String(prefixPath),
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, k := range result.Contents {
+		if strings.HasPrefix(*k.Key, prefix) {
+			keys = append(keys, *k.Key)
+		}
+	}
+	//
+	return keys, nil
+}
+
+
+// Stat returns information about key.
+func (s *S3Storage) Stat(key string) (KeyInfo, error) {
+
+	result, err := s.svc.GetObject(&s3.GetObjectInput{
+		Bucket: s.bucket,
+		Key: aws.String(key),
+	})
+
+	if err != nil {
+		return KeyInfo{}, err
+	}
+
+	return KeyInfo{
+		Key:key,
+		Size: *result.ContentLength,
+		Modified: *result.LastModified,
+		IsTerminal: true,
+	}, nil
+}
+
+// Filename returns the key as a path on the file
+// system prefixed by S3Storage.Path.
+func (s *S3Storage) Filename(key string) string {
+	return filepath.Join(s.Path, filepath.FromSlash(key))
+}
+
+// Lock obtains a lock named by the given key. It blocks
+// until the lock can be obtained or an error is returned.
+func (s *S3Storage) Lock(key string) error {
+	start := time.Now()
+	lockFile := s.lockFileName(key)
+
+	for {
+		err := s.createLockFile(lockFile)
+		if err == nil {
+			// got the lock, yay
+			return nil
+		}
+
+		if err.Error() != lockFileExists {
+			// unexpected error
+			fmt.Println(err)
+			return fmt.Errorf("creating lock file: %+v", err)
+
+		}
+
+		// lock file already exists
+
+		info, err := s.Stat(lockFile)
+		switch {
+		case s.errNoSuchKey(err) :
+			// must have just been removed; try again to create it
+			continue
+
+		case err != nil:
+			// unexpected error
+			return fmt.Errorf("accessing lock file: %v", err)
+
+		case s.fileLockIsStale(info):
+			log.Printf("[INFO][%s] Lock for '%s' is stale; removing then retrying: %s",
+				s, key, lockFile)
+			s.deleteLockFile(lockFile)
+			continue
+
+		case time.Since(start) > staleLockDuration*2:
+			// should never happen, hopefully
+			return fmt.Errorf("possible deadlock: %s passed trying to obtain lock for %s",
+				time.Since(start), key)
+
+		default:
+			// lockfile exists and is not stale;
+			// just wait a moment and try again
+			time.Sleep(fileLockPollInterval)
+
+		}
+	}
+}
+
+// Unlock releases the lock for name.
+func (s *S3Storage) Unlock(key string) error {
+	return s.deleteLockFile(s.lockFileName(key))
+}
+
+func (s *S3Storage) String() string {
+	return "S3Storage:" + s.Path
+}
+
+func (s *S3Storage) lockFileName(key string) string {
+	return filepath.Join(s.lockDir(), StorageKeys.safe(key)+".lock")
+}
+
+func (s *S3Storage) lockDir() string {
+	return filepath.Join(s.Path, "locks")
+}
+
+func (s *S3Storage) fileLockIsStale(info KeyInfo) bool {
+	return time.Since(info.Modified) > staleLockDuration
+}
+
+func (s *S3Storage) createLockFile(filename string) error {
+	//lf := s.lockFileName(key)
+	exists := s.Exists(filename)
+	if exists {
+		return fmt.Errorf(lockFileExists)
+	}
+	_, err := s.svc.PutObject(&s3.PutObjectInput{
+		Bucket: s.bucket,
+		Key: aws.String(filename),
+		Body: bytes.NewReader([]byte("lock")),
+	})
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *S3Storage) deleteLockFile(keyPath string) error {
+	_, err := s.svc.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: s.bucket,
+		Key: aws.String(keyPath),
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *S3Storage) errNoSuchKey(err error) bool {
+	if err != nil {
+		aerr, ok := err.(awserr.Error)
+		if !ok {
+			return false
+		}
+		if aerr.Code() == s3.ErrCodeNoSuchKey {
+			return true
+		}
+	}
+	return false
+}

--- a/s3storage_test.go
+++ b/s3storage_test.go
@@ -1,15 +1,15 @@
 package certmagic
 
 import (
-	"testing"
-	"time"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"bytes"
-	"io/ioutil"
 	"errors"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"io/ioutil"
+	"testing"
+	"time"
 )
 
 type mockedS3 struct {
@@ -18,9 +18,9 @@ type mockedS3 struct {
 }
 
 var (
-	MockStore = &S3Storage{}
+	MockStore    = &S3Storage{}
 	errPutObject = errors.New("could not put object")
-	tstamp = time.Now()
+	tstamp       = time.Now()
 )
 
 func init() {
@@ -40,8 +40,8 @@ func (m mockedS3) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, erro
 		if *input.Key == k {
 			rc := ioutil.NopCloser(bytes.NewReader(v))
 			return &s3.GetObjectOutput{
-				Body:rc,
-				LastModified: aws.Time(tstamp),
+				Body:          rc,
+				LastModified:  aws.Time(tstamp),
 				ContentLength: aws.Int64(int64(len(v))),
 			}, nil
 		}
@@ -70,7 +70,6 @@ func (m mockedS3) DeleteObject(input *s3.DeleteObjectInput) (*s3.DeleteObjectOut
 	return nil, awserr.New(s3.ErrCodeNoSuchKey, *input.Key, nil)
 }
 
-
 var testStore *S3Storage
 
 func init() {
@@ -78,13 +77,12 @@ func init() {
 }
 
 func TestS3Storage_Exists(t *testing.T) {
-	cases := []struct{
-		input string
+	cases := []struct {
+		input    string
 		expected bool
-
 	}{
 		{"existingKey", true},
-		{ "testKey", false},
+		{"testKey", false},
 	}
 	for _, c := range cases {
 		got := MockStore.Exists(c.input)
@@ -95,16 +93,15 @@ func TestS3Storage_Exists(t *testing.T) {
 }
 
 func TestS3Storage_Store(t *testing.T) {
-	cases := []struct{
-		inputKey string
+	cases := []struct {
+		inputKey   string
 		inputValue []byte
-		expected error
-
+		expected   error
 	}{
 		{"a key", []byte("Test"), nil},
-		{ "", nil, errPutObject},
-		{ "test", nil, errPutObject},
-		{ "", []byte("test"), errPutObject},
+		{"", nil, errPutObject},
+		{"test", nil, errPutObject},
+		{"", []byte("test"), errPutObject},
 	}
 	for _, c := range cases {
 		got := MockStore.Store(c.inputKey, c.inputValue)
@@ -115,10 +112,10 @@ func TestS3Storage_Store(t *testing.T) {
 }
 
 func TestS3Storage_Load(t *testing.T) {
-	cases := []struct{
-		input string
+	cases := []struct {
+		input    string
 		expected []byte
-	} {
+	}{
 		{"existingKey", []byte("test")},
 		{"nonExistentKey", nil},
 	}
@@ -144,16 +141,16 @@ func TestS3Storage_Delete(t *testing.T) {
 	input = "nonExistantKey"
 	got = MockStore.Delete(input)
 	if got == nil {
-		t.Errorf("\ninput: %s\nexpected: %+v\n     got: %+v", input, awserr.New(s3.ErrCodeNoSuchKey, MockStore.Filename(input), nil) , got)
+		t.Errorf("\ninput: %s\nexpected: %+v\n     got: %+v", input, awserr.New(s3.ErrCodeNoSuchKey, MockStore.Filename(input), nil), got)
 	}
 }
 
 func TestS3Storage_Stat(t *testing.T) {
-	cases := []struct{
-		input string
+	cases := []struct {
+		input    string
 		expected KeyInfo
-	} {
-		{"existingKey", KeyInfo{Key: "existingKey", Size: 4, Modified: tstamp, IsTerminal:true}},
+	}{
+		{"existingKey", KeyInfo{Key: "existingKey", Size: 4, Modified: tstamp, IsTerminal: true}},
 		{"nonExistentKey", KeyInfo{}},
 	}
 	for _, c := range cases {
@@ -163,7 +160,6 @@ func TestS3Storage_Stat(t *testing.T) {
 		}
 	}
 }
-
 
 func TestS3Storage_LockUnlock(t *testing.T) {
 	lock1 := "testLock1"
@@ -186,14 +182,12 @@ func TestS3Storage_LockUnlock(t *testing.T) {
 
 }
 
-
 func TestS3Storage_String(t *testing.T) {
 	expected := "S3Storage:certmagic"
 	if testStore.String() != expected {
 		t.Errorf("Expected: %s, go %s", expected, testStore.String())
 	}
 }
-
 
 func TestS3Storage_lockDir(t *testing.T) {
 	expected := "certmagic/locks"
@@ -205,8 +199,8 @@ func TestS3Storage_lockDir(t *testing.T) {
 
 func TestS3Storage_fileLockIsStale(t *testing.T) {
 	info := KeyInfo{
-		Key: "key",
-		Modified: time.Now().Add(-time.Hour*999),
+		Key:      "key",
+		Modified: time.Now().Add(-time.Hour * 999),
 	}
 	expected := true
 	got := testStore.fileLockIsStale(info)

--- a/s3storage_test.go
+++ b/s3storage_test.go
@@ -3,13 +3,14 @@ package certmagic
 import (
 	"bytes"
 	"errors"
+	"io/ioutil"
+	"testing"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"io/ioutil"
-	"testing"
-	"time"
 )
 
 type mockedS3 struct {

--- a/s3storage_test.go
+++ b/s3storage_test.go
@@ -61,7 +61,7 @@ func (m mockedS3) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, erro
 }
 
 func (m mockedS3) DeleteObject(input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
-	for k, _ := range m.objectKeys {
+	for k := range m.objectKeys {
 		if *input.Key == k {
 			delete(m.objectKeys, *input.Key)
 			return &s3.DeleteObjectOutput{}, nil

--- a/s3storage_test.go
+++ b/s3storage_test.go
@@ -1,0 +1,216 @@
+package certmagic
+
+import (
+	"testing"
+	"time"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"bytes"
+	"io/ioutil"
+	"errors"
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+type mockedS3 struct {
+	s3iface.S3API
+	objectKeys map[string][]byte
+}
+
+var (
+	MockStore = &S3Storage{}
+	errPutObject = errors.New("could not put object")
+	tstamp = time.Now()
+)
+
+func init() {
+
+	mocks3 := mockedS3{
+		objectKeys: make(map[string][]byte),
+	}
+	mocks3.objectKeys["existingKey"] = []byte("test")
+
+	MockStore = NewS3Storage("test-bucket", "us-east-1")
+	MockStore.svc = mocks3
+}
+
+func (m mockedS3) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	//rc := ioutil.NewReadCloser(bytes.NewReader([]byte("blobl")), nil)
+	for k, v := range m.objectKeys {
+		if *input.Key == k {
+			rc := ioutil.NopCloser(bytes.NewReader(v))
+			return &s3.GetObjectOutput{
+				Body:rc,
+				LastModified: aws.Time(tstamp),
+				ContentLength: aws.Int64(int64(len(v))),
+			}, nil
+		}
+	}
+	return nil, awserr.New(s3.ErrCodeNoSuchKey, *input.Key, nil)
+}
+
+func (m mockedS3) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	if len(*input.Key) > 9 {
+		bod, _ := ioutil.ReadAll(input.Body)
+		if len(bod) > 0 {
+			m.objectKeys[*input.Key] = bod
+			return &s3.PutObjectOutput{}, nil
+		}
+	}
+	return nil, errPutObject
+}
+
+func (m mockedS3) DeleteObject(input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+	for k, _ := range m.objectKeys {
+		if *input.Key == k {
+			delete(m.objectKeys, *input.Key)
+			return &s3.DeleteObjectOutput{}, nil
+		}
+	}
+	return nil, awserr.New(s3.ErrCodeNoSuchKey, *input.Key, nil)
+}
+
+
+var testStore *S3Storage
+
+func init() {
+	testStore = NewS3Storage("test-bucket", "us-east-1")
+}
+
+func TestS3Storage_Exists(t *testing.T) {
+	cases := []struct{
+		input string
+		expected bool
+
+	}{
+		{"existingKey", true},
+		{ "testKey", false},
+	}
+	for _, c := range cases {
+		got := MockStore.Exists(c.input)
+		if got != c.expected {
+			t.Errorf("\nexpected: %+v     \ngot: %+v", c.expected, got)
+		}
+	}
+}
+
+func TestS3Storage_Store(t *testing.T) {
+	cases := []struct{
+		inputKey string
+		inputValue []byte
+		expected error
+
+	}{
+		{"a key", []byte("Test"), nil},
+		{ "", nil, errPutObject},
+		{ "test", nil, errPutObject},
+		{ "", []byte("test"), errPutObject},
+	}
+	for _, c := range cases {
+		got := MockStore.Store(c.inputKey, c.inputValue)
+		if got != c.expected {
+			t.Errorf("\nexpected: %+v     \ngot: %+v", c.expected, got)
+		}
+	}
+}
+
+func TestS3Storage_Load(t *testing.T) {
+	cases := []struct{
+		input string
+		expected []byte
+	} {
+		{"existingKey", []byte("test")},
+		{"nonExistentKey", nil},
+	}
+
+	if err := MockStore.Store("existingKey", []byte("test")); err != nil {
+		t.Error(err)
+	}
+
+	for _, c := range cases {
+		got, _ := MockStore.Load(c.input)
+		if string(got) != string(c.expected) {
+			t.Errorf("\ninput: %s\nexpected: %+v     \ngot: %+v", c.input, string(c.expected), string(got))
+		}
+	}
+}
+
+func TestS3Storage_Delete(t *testing.T) {
+	input := "existingKey"
+	got := MockStore.Delete("existingKey")
+	if got != nil {
+		t.Errorf("\ninput: %s\nexpected: %+v\n     got: %+v", input, nil, got)
+	}
+	input = "nonExistantKey"
+	got = MockStore.Delete(input)
+	if got == nil {
+		t.Errorf("\ninput: %s\nexpected: %+v\n     got: %+v", input, awserr.New(s3.ErrCodeNoSuchKey, MockStore.Filename(input), nil) , got)
+	}
+}
+
+func TestS3Storage_Stat(t *testing.T) {
+	cases := []struct{
+		input string
+		expected KeyInfo
+	} {
+		{"existingKey", KeyInfo{Key: "existingKey", Size: 4, Modified: tstamp, IsTerminal:true}},
+		{"nonExistentKey", KeyInfo{}},
+	}
+	for _, c := range cases {
+		got, _ := MockStore.Stat(c.input)
+		if got != c.expected {
+			t.Errorf("\ninput: %s\nexpected: %+v\n     got: %+v", c.input, c.expected, got)
+		}
+	}
+}
+
+
+func TestS3Storage_LockUnlock(t *testing.T) {
+	lock1 := "testLock1"
+	got := MockStore.Lock(lock1)
+	if got != nil {
+		t.Errorf("\ninput: %s\nexpected: %+v\n     got: %+v", lock1, nil, got)
+	}
+
+	got = MockStore.Unlock(lock1)
+	if got != nil {
+		t.Errorf("\ninput: %s\nexpected: %+v\n     got: %+v", lock1, nil, got)
+	}
+
+	got = MockStore.Lock(lock1)
+	if got != nil {
+		t.Errorf("\ninput: %s\nexpected: %+v\n     got: %+v", lock1, nil, got)
+	}
+
+	//this should fail since we already have a lock on lock1
+
+}
+
+
+func TestS3Storage_String(t *testing.T) {
+	expected := "S3Storage:certmagic"
+	if testStore.String() != expected {
+		t.Errorf("Expected: %s, go %s", expected, testStore.String())
+	}
+}
+
+
+func TestS3Storage_lockDir(t *testing.T) {
+	expected := "certmagic/locks"
+	got := testStore.lockDir()
+	if got != expected {
+		t.Errorf("Expected: %s, got: %s", expected, got)
+	}
+}
+
+func TestS3Storage_fileLockIsStale(t *testing.T) {
+	info := KeyInfo{
+		Key: "key",
+		Modified: time.Now().Add(-time.Hour*999),
+	}
+	expected := true
+	got := testStore.fileLockIsStale(info)
+	if !got {
+		t.Errorf("Expected: %t, got: %t", expected, got)
+	}
+}


### PR DESCRIPTION
This is a new implementation of the `Storage` Interface which utilizes aws's S3 storage as a backend.

#### Changes: 
* Added: S3Storage.go - implements new S3Storage type
* Added: S3Storage_test.go - relevant tests
* Updated: REAME.md - documentation for S3Storage type.

I've done my absolute best to keep everything as close as possible to to original `Filestorage` implementation for the sake of understanding and ease of use, as well as troubleshooting.

I have tested this on a personal project with multiple EC2 instances behind an AWS LB and it is working as intended for me, but I would love it is other's would give it a real world test as well!

Feedback is 100% welcome and any comments on better ways to do things in the implementation is greatly appreciated.  Hopefully this is useful!