### PR TITLE
exported KeyBuilder.Safe to use with external pkgs

### DIFF
--- a/filestorage.go
+++ b/filestorage.go
@@ -179,7 +179,7 @@ func (fs *FileStorage) String() string {
 }
 
 func (fs *FileStorage) lockFilename(key string) string {
-	return filepath.Join(fs.lockDir(), StorageKeys.safe(key)+".lock")
+	return filepath.Join(fs.lockDir(), StorageKeys.Safe(key)+".lock")
 }
 
 func (fs *FileStorage) lockDir() string {

--- a/solvers.go
+++ b/solvers.go
@@ -140,7 +140,7 @@ func (dhs distributedSolver) challengeTokensPrefix() string {
 // challengeTokensKey returns the key to use to store and access
 // challenge info for domain.
 func (dhs distributedSolver) challengeTokensKey(domain string) string {
-	return filepath.Join(dhs.challengeTokensPrefix(), StorageKeys.safe(domain)+".json")
+	return filepath.Join(dhs.challengeTokensPrefix(), StorageKeys.Safe(domain)+".json")
 }
 
 type challengeInfo struct {

--- a/storage.go
+++ b/storage.go
@@ -221,7 +221,7 @@ func (keys KeyBuilder) emailUsername(email string) string {
 	return email[:at]
 }
 
-// safe standardizes and sanitizes str for use as
+// Safe standardizes and sanitizes str for use as
 // a storage key. This method is idempotent.
 func (keys KeyBuilder) Safe(str string) string {
 	str = strings.ToLower(str)

--- a/storage.go
+++ b/storage.go
@@ -130,28 +130,28 @@ func (keys KeyBuilder) CAPrefix(ca string) string {
 	if err != nil {
 		caURL = &url.URL{Host: ca}
 	}
-	return path.Join(prefixACME, keys.safe(caURL.Host))
+	return path.Join(prefixACME, keys.Safe(caURL.Host))
 }
 
 // SitePrefix returns a key prefix for items associated with
 // the site using the given CA URL.
 func (keys KeyBuilder) SitePrefix(ca, domain string) string {
-	return path.Join(keys.CAPrefix(ca), "sites", keys.safe(domain))
+	return path.Join(keys.CAPrefix(ca), "sites", keys.Safe(domain))
 }
 
 // SiteCert returns the path to the certificate file for domain.
 func (keys KeyBuilder) SiteCert(ca, domain string) string {
-	return path.Join(keys.SitePrefix(ca, domain), keys.safe(domain)+".crt")
+	return path.Join(keys.SitePrefix(ca, domain), keys.Safe(domain)+".crt")
 }
 
 // SitePrivateKey returns the path to domain's private key file.
 func (keys KeyBuilder) SitePrivateKey(ca, domain string) string {
-	return path.Join(keys.SitePrefix(ca, domain), keys.safe(domain)+".key")
+	return path.Join(keys.SitePrefix(ca, domain), keys.Safe(domain)+".key")
 }
 
 // SiteMeta returns the path to the domain's asset metadata file.
 func (keys KeyBuilder) SiteMeta(ca, domain string) string {
-	return path.Join(keys.SitePrefix(ca, domain), keys.safe(domain)+".json")
+	return path.Join(keys.SitePrefix(ca, domain), keys.Safe(domain)+".json")
 }
 
 // UsersPrefix returns a key prefix for items related to
@@ -166,7 +166,7 @@ func (keys KeyBuilder) UserPrefix(ca, email string) string {
 	if email == "" {
 		email = emptyEmail
 	}
-	return path.Join(keys.UsersPrefix(ca), keys.safe(email))
+	return path.Join(keys.UsersPrefix(ca), keys.Safe(email))
 }
 
 // UserReg gets the path to the registration file for the user
@@ -187,7 +187,7 @@ func (keys KeyBuilder) UserPrivateKey(ca, email string) string {
 func (keys KeyBuilder) OCSPStaple(cert *Certificate, pemBundle []byte) string {
 	var ocspFileName string
 	if len(cert.Names) > 0 {
-		firstName := keys.safe(cert.Names[0])
+		firstName := keys.Safe(cert.Names[0])
 		ocspFileName = firstName + "-"
 	}
 	ocspFileName += fastHash(pemBundle)
@@ -205,7 +205,7 @@ func (keys KeyBuilder) safeUserKey(ca, email, defaultFilename, extension string)
 	if filename == "" {
 		filename = defaultFilename
 	}
-	filename = keys.safe(filename)
+	filename = keys.Safe(filename)
 	return path.Join(keys.UserPrefix(ca, email), filename+extension)
 }
 
@@ -223,7 +223,7 @@ func (keys KeyBuilder) emailUsername(email string) string {
 
 // safe standardizes and sanitizes str for use as
 // a storage key. This method is idempotent.
-func (keys KeyBuilder) safe(str string) string {
+func (keys KeyBuilder) Safe(str string) string {
 	str = strings.ToLower(str)
 	str = strings.TrimSpace(str)
 


### PR DESCRIPTION
Really simple change here.  Simply changing the `KeyBuilder.Safe()` function to be exported instead of internal to certmagic.  This allows other storage implementations to take advantage of the method without re-implementing the entire type.

Hope that's OK and makes sense!