### PR TITLE
user: don't create new user in getEmail

### DIFF
--- a/config.go
+++ b/config.go
@@ -369,12 +369,9 @@ func (cfg *Config) preObtainOrRenewChecks(name string, allowPrompts bool) (bool,
 		return true, nil
 	}
 
-	if cfg.Email == "" {
-		var err error
-		cfg.Email, err = cfg.getEmail(allowPrompts)
-		if err != nil {
-			return false, err
-		}
+	err := cfg.getEmail(allowPrompts)
+	if err != nil {
+		return false, err
 	}
 
 	return false, nil


### PR DESCRIPTION
This PR fixes mholt/caddy#2400

The initial problem can be reproduced by this test.
https://github.com/crvv/certmagic/commit/c48d69ec1aa2b9e6abee1b666dcf43c2899930b6

However, `getEmail` doesn't need to create the new user.
The new user will be created by `newACMEClient` and the new user will be saved to disk after registration in `newACMEClient`.

With this PR, `getEmail` just get an email and save that value to `Config`.
