### PR TITLE
Allow disabling certificate renewal

### DIFF
--- a/certificates.go
+++ b/certificates.go
@@ -68,6 +68,9 @@ func (c Certificate) NeedsRenewal() bool {
 	if len(c.configs) > 0 && c.configs[0].RenewDurationBefore > 0 {
 		renewDurationBefore = c.configs[0].RenewDurationBefore
 	}
+	if renewDurationBefore < 0 {
+		return false
+	}
 	return time.Until(c.NotAfter) < renewDurationBefore
 }
 

--- a/config.go
+++ b/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	DisableTLSALPNChallenge bool
 
 	// How long before expiration to renew certificates
+	// Setting this to a negative value disables renewal
 	RenewDurationBefore time.Duration
 
 	// How long before expiration to require a renewed


### PR DESCRIPTION
Setting `Config.RenewalDurationBefore` to a negative value will
disable certificate renewal.

Closes #21