### PR TITLE
use go-acme/lego

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ install:
   - go get github.com/alecthomas/gometalinter
 
 script:
-  - gometalinter --install
-  - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E goimports -E deadcode --tests ./...
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+  - golangci-lint run  --disable-all -E vet -E gofmt -E misspell -E ineffassign -E goimports -E deadcode --tests
   - go test -race ./...
 
 after_script:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ CertMagic - Automatic HTTPS using Let's Encrypt
 - Full control over almost every aspect of the system
 - HTTP->HTTPS redirects (for HTTP applications)
 - Solves all 3 ACME challenges: HTTP, TLS-ALPN, and DNS
-- Over 50 DNS providers work out-of-the-box (powered by [lego](https://github.com/xenolf/lego)!)
+- Over 50 DNS providers work out-of-the-box (powered by [lego](https://github.com/go-acme/lego)!)
 - Pluggable storage implementations (default: file system)
 - Wildcard certificates (requires DNS challenge)
 - OCSP stapling for each qualifying certificate ([done right](https://gist.github.com/sleevi/5efe9ef98961ecfb4da8#gistcomment-2336055))
@@ -348,12 +348,12 @@ ln, err := tls.Listen("tcp", ":443", myTLSConfig)
 
 The DNS challenge is perhaps the most useful challenge because it allows you to obtain certificates without your server needing to be publicly accessible on the Internet, and it's the only challenge by which Let's Encrypt will issue wildcard certificates.
 
-This challenge works by setting a special record in the domain's zone. To do this automatically, your DNS provider needs to offer an API by which changes can be made to domain names, and the changes need to take effect immediately for best results. CertMagic supports [all of lego's DNS provider implementations](https://github.com/xenolf/lego/tree/master/providers/dns)! All of them clean up the temporary record after the challenge completes.
+This challenge works by setting a special record in the domain's zone. To do this automatically, your DNS provider needs to offer an API by which changes can be made to domain names, and the changes need to take effect immediately for best results. CertMagic supports [all of lego's DNS provider implementations](https://github.com/go-acme/lego/tree/master/providers/dns)! All of them clean up the temporary record after the challenge completes.
 
 To enable it, just set the `DNSProvider` field on a `certmagic.Config` struct, or set the default `certmagic.DNSProvider` variable. For example, if my domains' DNS was served by DNSimple and I set my DNSimple API credentials in environment variables:
 
 ```go
-import "github.com/xenolf/lego/providers/dns/dnsimple"
+import "github.com/go-acme/lego/providers/dns/dnsimple"
 
 provider, err := dnsimple.NewDNSProvider()
 if err != nil {
@@ -363,7 +363,7 @@ if err != nil {
 certmagic.DNSProvider = provider
 ```
 
-Now the DNS challenge will be used by default, and I can obtain certificates for wildcard domains. See the [godoc documentation for the provider you're using](https://godoc.org/github.com/xenolf/lego/providers/dns#pkg-subdirectories) to learn how to configure it. Most can be configured by env variables or by passing in a config struct. If you pass a config struct instead of using env variables, you will probably need to set some other defaults (that's just how lego works, currently):
+Now the DNS challenge will be used by default, and I can obtain certificates for wildcard domains. See the [godoc documentation for the provider you're using](https://godoc.org/github.com/go-acme/lego/providers/dns#pkg-subdirectories) to learn how to configure it. Most can be configured by env variables or by passing in a config struct. If you pass a config struct instead of using env variables, you will probably need to set some other defaults (that's just how lego works, currently):
 
 ```go
 PropagationTimeout: dns01.DefaultPollingInterval,
@@ -460,7 +460,7 @@ We welcome your contributions! Please see our **[contributing guidelines](https:
 
 ## Project History
 
-CertMagic is the core of Caddy's advanced TLS automation code, extracted into a library. The underlying ACME client implementation is [lego](https://github.com/xenolf/lego), which was originally developed for use in Caddy even before Let's Encrypt entered public beta in 2015.
+CertMagic is the core of Caddy's advanced TLS automation code, extracted into a library. The underlying ACME client implementation is [lego](https://github.com/go-acme/lego), which was originally developed for use in Caddy even before Let's Encrypt entered public beta in 2015.
 
 In the years since then, Caddy's TLS automation techniques have been widely adopted, tried and tested in production, and served millions of sites and secured trillions of connections.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,6 @@ before_test:
   - go env
 
 test_script:
-  - wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.15.0
-  - golangci-lint run  --disable-all -E vet -E gofmt -E misspell -E ineffassign -E goimports -E deadcode --tests
   - go test -race ./...
 
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,8 @@ before_test:
   - go env
 
 test_script:
-  - gometalinter --install
-  - gometalinter --disable-all -E vet -E gofmt -E misspell -E ineffassign -E goimports -E deadcode --tests ./...
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+  - golangci-lint run  --disable-all -E vet -E gofmt -E misspell -E ineffassign -E goimports -E deadcode --tests
   - go test -race ./...
 
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ before_test:
   - go env
 
 test_script:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.15.0
+  - wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.15.0
   - golangci-lint run  --disable-all -E vet -E gofmt -E misspell -E ineffassign -E goimports -E deadcode --tests
   - go test -race ./...
 

--- a/certmagic.go
+++ b/certmagic.go
@@ -45,8 +45,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/xenolf/lego/certcrypto"
-	"github.com/xenolf/lego/challenge"
+	"github.com/go-acme/lego/certcrypto"
+	"github.com/go-acme/lego/challenge"
 )
 
 // HTTPS serves mux for all domainNames using the HTTP

--- a/client.go
+++ b/client.go
@@ -23,12 +23,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/xenolf/lego/certificate"
-	"github.com/xenolf/lego/challenge"
-	"github.com/xenolf/lego/challenge/http01"
-	"github.com/xenolf/lego/challenge/tlsalpn01"
-	"github.com/xenolf/lego/lego"
-	"github.com/xenolf/lego/registration"
+	"github.com/go-acme/lego/certificate"
+	"github.com/go-acme/lego/challenge"
+	"github.com/go-acme/lego/challenge/http01"
+	"github.com/go-acme/lego/challenge/tlsalpn01"
+	"github.com/go-acme/lego/lego"
+	"github.com/go-acme/lego/registration"
 )
 
 // acmeMu ensures that only one ACME challenge occurs at a time.

--- a/config.go
+++ b/config.go
@@ -20,11 +20,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/xenolf/lego/certcrypto"
-	"github.com/xenolf/lego/certificate"
-	"github.com/xenolf/lego/challenge"
-	"github.com/xenolf/lego/challenge/tlsalpn01"
-	"github.com/xenolf/lego/lego"
+	"github.com/go-acme/lego/certcrypto"
+	"github.com/go-acme/lego/certificate"
+	"github.com/go-acme/lego/challenge"
+	"github.com/go-acme/lego/challenge/tlsalpn01"
+	"github.com/go-acme/lego/lego"
 )
 
 // Config configures a certificate manager instance.

--- a/config_test.go
+++ b/config_test.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/xenolf/lego/certificate"
+	"github.com/go-acme/lego/certificate"
 )
 
 func TestSaveCertResource(t *testing.T) {

--- a/crypto.go
+++ b/crypto.go
@@ -27,7 +27,7 @@ import (
 	"hash/fnv"
 
 	"github.com/klauspost/cpuid"
-	"github.com/xenolf/lego/certificate"
+	"github.com/go-acme/lego/certificate"
 )
 
 // encodePrivateKey marshals a EC or RSA private key into a PEM-encoded array of bytes.

--- a/crypto.go
+++ b/crypto.go
@@ -26,8 +26,8 @@ import (
 	"fmt"
 	"hash/fnv"
 
-	"github.com/klauspost/cpuid"
 	"github.com/go-acme/lego/certificate"
+	"github.com/klauspost/cpuid"
 )
 
 // encodePrivateKey marshals a EC or RSA private key into a PEM-encoded array of bytes.

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/mholt/certmagic
 
 require (
+	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
+	github.com/go-acme/lego v2.3.1-0.20190318164254-3684cc738d37+incompatible
 	github.com/klauspost/cpuid v1.2.0
 	github.com/miekg/dns v1.1.3 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect
-	github.com/xenolf/lego v2.1.0+incompatible
 	golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b
 	golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3 // indirect
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
+github.com/cenkalti/backoff v2.1.1+incompatible h1:tKJnvO2kl0zmb/jA5UKAt4VoEVw1qxKWjE/Bpp46npY=
+github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-acme/lego v2.3.1-0.20190318164254-3684cc738d37+incompatible h1:D8mQOFMowsqoVMibY3U+xeNmd83bdNPEjTScRiPgVoc=
+github.com/go-acme/lego v2.3.1-0.20190318164254-3684cc738d37+incompatible/go.mod h1:yzMNe9CasVUhkquNvti5nAtPmG94USbYxYrZfTkIn0M=
 github.com/klauspost/cpuid v1.2.0 h1:NMpwD2G9JSFOE1/TJjGSo5zG7Yb2bTe7eq1jH+irmeE=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/miekg/dns v1.1.3 h1:1g0r1IvskvgL8rR+AcHzUA+oFmGcQlaIm4IqakufeMM=
@@ -9,8 +13,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/xenolf/lego v2.1.0+incompatible h1:zZErna+4KHeBsUC3mw6gthaXncPDoBuFJOHKCRl64Wg=
-github.com/xenolf/lego v2.1.0+incompatible/go.mod h1:fwiGnfsIjG7OHPfOvgK7Y/Qo6+2Ox0iozjNTkZICKbY=
 golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b h1:Elez2XeF2p9uyVj0yEUDqQ56NFcDtcBNkYP7yv8YbUE=
 golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3 h1:ulvT7fqt0yHWzpJwI57MezWnYDVpCAYBVuYst/L+fAY=

--- a/handshake.go
+++ b/handshake.go
@@ -25,7 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/xenolf/lego/challenge/tlsalpn01"
+	"github.com/go-acme/lego/challenge/tlsalpn01"
 )
 
 // GetCertificate gets a certificate to satisfy clientHello. In getting

--- a/httphandler.go
+++ b/httphandler.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/xenolf/lego/challenge/http01"
+	"github.com/go-acme/lego/challenge/http01"
 )
 
 // HTTPChallengeHandler wraps h in a handler that can solve the ACME

--- a/ocsp.go
+++ b/ocsp.go
@@ -121,7 +121,7 @@ func (certCache *Cache) stapleOCSP(cert *Certificate, pemBundle []byte) error {
 // IssuingCertificateURL in the certificate. If the []byte and/or ocsp.Response return
 // values are nil, the OCSP status may be assumed OCSPUnknown.
 //
-// Borrowed from github.com/xenolf/lego
+// Borrowed from github.com/go-acme/lego
 func getOCSPForCert(bundle []byte) ([]byte, *ocsp.Response, error) {
 	// TODO: Perhaps this should be synchronized too, with a Locker?
 

--- a/solvers.go
+++ b/solvers.go
@@ -20,8 +20,8 @@ import (
 	"log"
 	"path/filepath"
 
-	"github.com/xenolf/lego/challenge"
-	"github.com/xenolf/lego/challenge/tlsalpn01"
+	"github.com/go-acme/lego/challenge"
+	"github.com/go-acme/lego/challenge/tlsalpn01"
 )
 
 // tlsALPNSolver is a type that can solve TLS-ALPN challenges using

--- a/user.go
+++ b/user.go
@@ -29,8 +29,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/xenolf/lego/acme"
-	"github.com/xenolf/lego/registration"
+	"github.com/go-acme/lego/acme"
+	"github.com/go-acme/lego/registration"
 )
 
 // user represents a Let's Encrypt user account.

--- a/user_test.go
+++ b/user_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/xenolf/lego/registration"
+	"github.com/go-acme/lego/registration"
 )
 
 func TestUser(t *testing.T) {


### PR DESCRIPTION
Getting errors when trying to `go get ./...` in caddy

```
../../mholt/certmagic/client.go:98:29: cannot use &leUser (type *user) as type "github.com/go-acme/lego/registration".User in argument to lego.NewConfig:
 	*user does not implement "github.com/go-acme/lego/registration".User (wrong type for GetRegistration method)
 		have GetRegistration() *"github.com/xenolf/lego/registration".Resource
 		want GetRegistration() *"github.com/go-acme/lego/registration".Resource
 ../../mholt/certmagic/client.go:103:4: cannot use keyType (type "github.com/xenolf/lego/certcrypto".KeyType) as type "github.com/go-acme/lego/certcrypto".KeyType in field value
 ../../mholt/certmagic/client.go:128:72: cannot use "github.com/xenolf/lego/registration".RegisterOptions literal (type "github.com/xenolf/lego/registration".RegisterOptions) as type "github.com/go-acme/lego/registration".RegisterOptions in argument to client.Registration.Register
 ../../mholt/certmagic/client.go:132:23: cannot use reg (type *"github.com/go-acme/lego/registration".Resource) as type *"github.com/xenolf/lego/registration".Resource in assignment
 ../../mholt/certmagic/client.go:200:33: cannot use "github.com/xenolf/lego/challenge".HTTP01 (type "github.com/xenolf/lego/challenge".Type) as type "github.com/go-acme/lego/challenge".Type in argument to c.acmeClient.Challenge.Remove
 ../../mholt/certmagic/client.go:203:33: cannot use "github.com/xenolf/lego/challenge".TLSALPN01 (type "github.com/xenolf/lego/challenge".Type) as type "github.com/go-acme/lego/challenge".Type in argument to c.acmeClient.Challenge.Remove
 ../../mholt/certmagic/client.go:207:32: cannot use "github.com/xenolf/lego/challenge".HTTP01 (type "github.com/xenolf/lego/challenge".Type) as type "github.com/go-acme/lego/challenge".Type in argument to c.acmeClient.Challenge.Remove
 ../../mholt/certmagic/client.go:208:32: cannot use "github.com/xenolf/lego/challenge".TLSALPN01 (type "github.com/xenolf/lego/challenge".Type) as type "github.com/go-acme/lego/challenge".Type in argument to c.acmeClient.Challenge.Remove
 ../../mholt/certmagic/client.go:259:54: cannot use request (type "github.com/xenolf/lego/certificate".ObtainRequest) as type "github.com/go-acme/lego/certificate".ObtainRequest in argument to c.acmeClient.Certificate.Obtain
 ../../mholt/certmagic/client.go:271:34: cannot use certificate (type *"github.com/go-acme/lego/certificate".Resource) as type *"github.com/xenolf/lego/certificate".Resource in argument to c.config.saveCertResource
 ../../mholt/certmagic/client.go:271:34: too many errors
```

looks related to #29, hopefully fixes that.

Other changes:
- Removed `gometalinter` since it is deprecated and was causing builds to fail
- Replaced `gometalinter` with `golangci-lint`
- `golangci-lint` won't install in Appveyor, removed it from Appveyor config