### PR TITLE
Change default KeyType to EC256 (P256)

### DIFF
--- a/certmagic.go
+++ b/certmagic.go
@@ -474,7 +474,7 @@ var (
 
 	// The type of key to use when generating
 	// certificates
-	KeyType = certcrypto.RSA2048
+	KeyType = certcrypto.EC256
 
 	// The maximum amount of time to allow for
 	// obtaining a certificate. If empty, the


### PR DESCRIPTION
will also allow IE11 to use GCM ciphers (indirect fix for mholt/caddy#2496 )