### PR TITLE
Add an Config option for custom ChallengeOptions

### DIFF
--- a/client.go
+++ b/client.go
@@ -579,7 +579,11 @@ func (c *acmeClient) nextChallenge(available []challenge.Type) (challenge.Type, 
 		})
 
 	case challenge.DNS01:
-		c.acmeClient.Challenge.SetDNS01Provider(c.config.DNSProvider)
+		if c.config.DNSChallengeOption != nil {
+			c.acmeClient.Challenge.SetDNS01Provider(c.config.DNSProvider, c.config.DNSChallengeOption)
+		} else {
+			c.acmeClient.Challenge.SetDNS01Provider(c.config.DNSProvider)
+		}
 	}
 
 	return randomChallenge, available

--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-acme/lego/v3/certcrypto"
 	"github.com/go-acme/lego/v3/certificate"
 	"github.com/go-acme/lego/v3/challenge"
+	"github.com/go-acme/lego/v3/challenge/dns01"
 	"github.com/go-acme/lego/v3/challenge/tlsalpn01"
 	"github.com/go-acme/lego/v3/lego"
 )
@@ -82,6 +83,11 @@ type Config struct {
 	// The DNS provider to use when solving the
 	// ACME DNS challenge
 	DNSProvider challenge.Provider
+
+	// The ChallengeOption struct to provide
+	// custom precheck or name resolution options
+	// for DNS challenge validation and execution
+	DNSChallengeOption dns01.ChallengeOption
 
 	// The type of key to use when generating
 	// certificates
@@ -248,6 +254,9 @@ func newWithCache(certCache *Cache, cfg Config) *Config {
 	}
 	if cfg.DNSProvider == nil {
 		cfg.DNSProvider = Default.DNSProvider
+	}
+	if cfg.DNSChallengeOption == nil {
+		cfg.DNSChallengeOption = Default.DNSChallengeOption
 	}
 	if cfg.KeyType == "" {
 		cfg.KeyType = Default.KeyType


### PR DESCRIPTION
This PR adds a new Config option to allow the user to define custom `dns01.ChallengeOption` for their `dns01.Provider`. This gives optionally more control for the advanced users of certmagic.

#### Problem description and example use case:
When running DNS servers behind firewalls with address translation, it may prove difficult for the default validation functions of `lego` to successfully return. This is true even in cases where the validation should succeed. 

The reason for this is that some firewalls struggle with packets from LAN towards WAN IP that actually points back to the LAN. This is usually handled by [split-horizon DNS](https://en.wikipedia.org/wiki/Split-horizon_DNS), but in this use case it proves insufficient.

With this option, the user is able to add a custom DNS resolvers, modify the propagation check rules or change the preCheck validation logic to suit their needs.